### PR TITLE
fix(actions): guard deployments and configure Pages environment

### DIFF
--- a/.github/workflows/deploy-every-day.yml
+++ b/.github/workflows/deploy-every-day.yml
@@ -307,6 +307,9 @@ jobs:
     needs: [wcag-test, merge-summaries]
     runs-on: ubuntu-24.04
     if: success()
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,9 +189,9 @@ jobs:
           retention-days: 3
 
   merge-summaries:
-    needs: wcag-test
+    needs: [gate, wcag-test]
     runs-on: ubuntu-24.04
-    if: always()
+    if: ${{ always() && (needs.gate.outputs.run == 'true' || github.event_name == 'workflow_dispatch') && needs.wcag-test.result == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -261,7 +261,7 @@ jobs:
   deploy:
     needs: [gate, wcag-test, merge-summaries]
     runs-on: ubuntu-24.04
-    if: ${{ always() && (needs.gate.outputs.run == 'true' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ always() && (needs.gate.outputs.run == 'true' || github.event_name == 'workflow_dispatch') && needs.merge-summaries.result == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Fixes two recurring GitHub Actions failures:

1. Adds the required `github-pages` environment to the daily Pages deployment job.
2. Prevents the first-Sunday workflow from running merge/deploy jobs when the gate intentionally skips tests, and requires a successful summary merge before deployment.

## Validation

- Reviewed against failed workflow runs 31286003536 and 31285559162.
- `git diff --check` passed locally.

The missing `invalid-urls-files` artifact remains non-fatal because its download is already configured with `continue-on-error: true`.